### PR TITLE
Fix admin page: include regular bills in totals and splits

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,8 +51,11 @@ const App: React.FC = () => {
       .filter(rb => rb.frequency === 'monthly')
       .reduce((sum, rb) => sum + rb.amount, 0);
 
+    // Calculate the total from regular bills (one-time bills)
+    const regularBillsTotal = bills.reduce((sum, bill) => sum + bill.amount, 0);
+
     // The main total is the sum of these planned amounts.
-    const totalMonthly = mortgagesTotal + monthlyRecurringBillsTotal;
+    const totalMonthly = mortgagesTotal + monthlyRecurringBillsTotal + regularBillsTotal;
 
     // The "Split Totals" are calculated separately based on the same set of items.
     const perPersonTotals: { [key: string]: number } = {};
@@ -78,7 +81,18 @@ const App: React.FC = () => {
       .filter(rb => rb.frequency === 'monthly')
       .forEach(bill => {
         const calculatedSplits = calculateSplitAmounts(bill, people);
-        
+
+        calculatedSplits.forEach(split => {
+            if (perPersonTotals[split.personId] !== undefined) {
+                perPersonTotals[split.personId] += split.amount;
+            }
+        });
+    });
+
+    // Process splits for regular bills (one-time bills).
+    bills.forEach(bill => {
+        const calculatedSplits = calculateSplitAmounts(bill, people);
+
         calculatedSplits.forEach(split => {
             if (perPersonTotals[split.personId] !== undefined) {
                 perPersonTotals[split.personId] += split.amount;
@@ -92,7 +106,7 @@ const App: React.FC = () => {
     }));
 
     return { totalMonthly, perPersonTotals: finalPerPersonTotals };
-  }, [people, mortgages, recurringBills]);
+  }, [people, mortgages, recurringBills, bills]);
 
   const handleViewChangeRequest = (newView: 'manage' | 'family') => {
     if (newView === 'family') {


### PR DESCRIPTION
## Summary

Fixes a bug where regular bills (one-time bills) were not being displayed in the admin page summary calculations.

### Problem
The admin page "Monthly Overview" section was only showing:
- ✅ Mortgage payments 
- ✅ Monthly recurring bills
- ❌ **Regular bills were completely missing**

This caused regular bills to be invisible in both the total amount and per-person split calculations.

### Solution
Updated the totals calculation in `App.tsx` to include regular bills:

**Total Calculation Changes:**
- Added `regularBillsTotal` calculation that sums all regular bills
- Included regular bills total in the overall `totalMonthly` amount

**Split Calculation Changes:**
- Added processing for regular bill splits in per-person totals
- Updated `useMemo` dependency array to include `bills` 

### Before vs After
**Before:** Only recurring bills and mortgages visible in summary
**After:** All bills (regular, recurring, and mortgages) included in totals and splits

### Files Changed
- `App.tsx` - Updated totals calculation logic (lines 43-109)

## Test plan
- [x] TypeScript compilation passes
- [ ] Verify regular bills now appear in "Total Monthly Bills & Mortgages"
- [ ] Verify regular bill splits appear in "Split Totals" per-person breakdown
- [ ] Confirm existing mortgage and recurring bill functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)