### PR TITLE
Fix React initialization error: reorder useMemo hooks

### DIFF
--- a/components/BillModal.tsx
+++ b/components/BillModal.tsx
@@ -112,6 +112,19 @@ export const BillModal: React.FC<BillModalProps> = ({ isOpen, onClose, onSave, o
     }
   };
 
+  // Calculate monthly payment for financing
+  const monthlyPayment = useMemo(() => {
+    if (!isFinanced || !totalAmount || !interestRate || !financingTerm) return 0;
+
+    const principal = totalAmount;
+    const monthlyRate = (typeof interestRate === 'number' ? interestRate : 0) / 100 / 12;
+    const months = typeof financingTerm === 'number' ? financingTerm : 0;
+
+    if (monthlyRate === 0) return principal / months;
+
+    return principal * (monthlyRate * Math.pow(1 + monthlyRate, months)) / (Math.pow(1 + monthlyRate, months) - 1);
+  }, [isFinanced, totalAmount, interestRate, financingTerm]);
+
   const { isValid, message } = useMemo(() => {
     const total = splits.reduce((sum, s) => sum + (Number(s.value) || 0), 0);
     const amountToValidate = isFinanced ? monthlyPayment : totalAmount;
@@ -138,20 +151,7 @@ export const BillModal: React.FC<BillModalProps> = ({ isOpen, onClose, onSave, o
       default:
         return { isValid: false, message: 'Invalid split mode' };
     }
-  }, [splits, splitMode, totalAmount, isFinanced]);
-
-  // Calculate monthly payment for financing
-  const monthlyPayment = useMemo(() => {
-    if (!isFinanced || !totalAmount || !interestRate || !financingTerm) return 0;
-
-    const principal = totalAmount;
-    const monthlyRate = (typeof interestRate === 'number' ? interestRate : 0) / 100 / 12;
-    const months = typeof financingTerm === 'number' ? financingTerm : 0;
-
-    if (monthlyRate === 0) return principal / months;
-
-    return principal * (monthlyRate * Math.pow(1 + monthlyRate, months)) / (Math.pow(1 + monthlyRate, months) - 1);
-  }, [isFinanced, totalAmount, interestRate, financingTerm]);
+  }, [splits, splitMode, totalAmount, isFinanced, monthlyPayment]);
 
   const isSaveDisabled = useMemo(() => {
     const basicValidation = name === '' || totalAmount <= 0 || !isValid || people.length === 0;


### PR DESCRIPTION
Move monthlyPayment calculation before isValid validation to fix 'Cannot access before initialization' error when using financing checkbox.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Brief description of the changes and why they were made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Performance improvement
- [ ] Dependency update

## Changes Made
- List the main changes made in this PR
- Use bullet points for clarity
- Include any database schema changes
- Note any new dependencies added

## Testing
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Database Changes
- [ ] No database changes
- [ ] Schema changes (migrations included)
- [ ] Seed data changes
- [ ] Breaking database changes (requires data migration)

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Requires environment variable changes
- [ ] Requires database migration
- [ ] Requires manual steps (document below)

### Manual Deployment Steps
If any manual steps are required for deployment, list them here:

## Screenshots (if applicable)
Add screenshots to help explain your changes

## Related Issues
Closes #(issue number)
Related to #(issue number)

## Additional Notes
Any additional information that reviewers should know